### PR TITLE
urls.defaults is no longer in django

### DIFF
--- a/locking/tests/urls.py
+++ b/locking/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from django.conf import settings
 from django.contrib import admin
 

--- a/locking/urls.py
+++ b/locking/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns
 
 urlpatterns = patterns('locking.views',
     # verwijst naar een ajax-view voor het lockingmechanisme


### PR DESCRIPTION
Supporting Django 1.8 upgrade
